### PR TITLE
Fix Enforcer hit generated by -mcrt=nix13 "hello world" program when started from Workbench

### DIFF
--- a/sources/nix20/stdio/__initstdio.c
+++ b/sources/nix20/stdio/__initstdio.c
@@ -162,7 +162,7 @@ void __initstdio(void) {
 				struct Process * proc = (struct Process *) SysBase->ThisTask;
 #ifdef __KICK13__
 				struct CommandLineInterface * cli = (struct CommandLineInterface *)BADDR(proc->pr_CLI);
-				bstderr = cli->cli_StandardOutput;
+				bstderr = cli ? cli->cli_StandardOutput : 0;
 #else
 				bstderr = proc->pr_CES;
 #endif


### PR DESCRIPTION
Consider the following hello world program:
```
#include <stdio.h>

int main()
{
    puts("hello world\n");
    return 0;
}
```

When compiled with `-mcrt=nix13`, the program - if given an `.info` icon and started from Workbench - will generate an Enforcer hit like so:
```
LONG READ from 00000038                        PC: 002D3EC4.
USP : 002CB61C SR: 0004  (U0)(-)(-)  TCB: 002CA558.
Data: 00000000 002BD5E4 FFFFFFFF 00000000 00000062 00000062 00000000 00000000.
Addr: 00000000 002DD200 002D3DE4 002BDC48 00000000 002BD718 0021075C 002022A4.
Stck: FFFFFFFF 002BDC38 002BDC48 00200884 002D3334 002D32D0 00F9DF4A 00001000.
Stck: 68656C6C 6F000000 00000000 0A0A0A0A 0A0A0A0A 0A0A0A0A 0A0A0A0A 0A0A0A0A.
002d3ea2 :  4eae ffc4                  jsr -$3c(a6).
002d3ea6 :  2f00                       move.l d0,-(a7).
002d3ea8 :  4e92                       jsr (a2).
002d3eaa :  588f                       addq.l #$4,a7.
002d3eac :  4a80                       tst.l d0.
002d3eae :  6700 00f0                  beq $2d3fa0.
002d3eb2 :  2079 002b d768             movea.l $2bd768,a0.
002d3eb8 :  2068 0114                  movea.l $114(a0),a0.
002d3ebc :  2028 00ac                  move.l $ac(a0),d0.
002d3ec0 :  e588                       lsl.l #$2,d0.
002d3ec2 :  2040                       movea.l d0,a0.
002d3ec4 : *2028 0038                  move.l $38(a0),d0.
002d3ec8 :  6700 008a                  beq $2d3f54.
002d3ecc :  2f00                       move.l d0,-(a7).
002d3ece :  4e92                       jsr (a2).
002d3ed0 :  588f                       addq.l #$4,a7.
002d3ed2 :  4a80                       tst.l d0.
002d3ed4 :  6700 00ca                  beq $2d3fa0.
002d3ed8 :  2079 002b d78c             movea.l $2bd78c,a0.
002d3ede :  42a8 000c                  clr.l $c(a0).
002d3ee2 :  2679 002b dd5c             movea.l $2bdd5c,a3.
Name: "hello"  Hunk 0000 Offset 00000C3C.
```

This hit corresponds to the following line of code:
https://github.com/bebbo/libnix/blob/cbab4db2e6aef2cfb9d2cd9462f7ef182cbdb148/sources/nix20/stdio/__initstdio.c#L165

...because `proc->pr_CLI` is `NULL` when the program is started from Workbench.

This PR should fix the issue.