### PR TITLE
Add strsep()

### DIFF
--- a/sources/headers/string.h
+++ b/sources/headers/string.h
@@ -37,6 +37,7 @@ __stdargs size_t strspn(const char *, const char *);
 __stdargs char *strstr(const char *, const char *);
 __stdargs char *strtok(char *, const char *);
 __stdargs char* strtok_r(char *str, const char *delim, char **nextp);
+__stdargs char* strsep(char **sp, char *sep);
 __stdargs size_t strxfrm(char *, const char *, size_t);
 __stdargs char *strupr(char *s);
 

--- a/sources/nix/string/strsep.c
+++ b/sources/nix/string/strsep.c
@@ -1,0 +1,13 @@
+  
+#include <string.h>
+
+char * strsep(char **sp, char *sep)
+{
+    char *p, *s;
+    if (sp == NULL || *sp == NULL || **sp == '\0') return(NULL);
+    s = *sp;
+    p = s + strcspn(s, sep);
+    if (*p != '\0') *p++ = '\0';
+    *sp = p;
+    return(s);
+}

--- a/sources/nix/string/strsep.c
+++ b/sources/nix/string/strsep.c
@@ -1,6 +1,6 @@
 #include <string.h>
 
-char * strsep(char **sp, char *sep)
+char* strsep(char **sp, char *sep)
 {
     char *p, *s;
     if (sp == NULL || *sp == NULL || **sp == '\0') return(NULL);

--- a/sources/nix/string/strsep.c
+++ b/sources/nix/string/strsep.c
@@ -1,4 +1,3 @@
-  
 #include <string.h>
 
 char * strsep(char **sp, char *sep)


### PR DESCRIPTION
It's not part of the C standard, but it is widely available in NIX systems
> The strsep() function was introduced as a replacement for strtok(3), since the latter cannot handle empty fields.

