### PR TITLE
Fix typos in function aliases

### DIFF
--- a/sources/nix/extra/strupper.c
+++ b/sources/nix/extra/strupper.c
@@ -1,6 +1,6 @@
 #include <ctype.h>
 
-asm("_strupr: .global strupr");
+asm("_strupr: .global _strupr");
 char *strupper(char *s)
 { unsigned char *s1;
 

--- a/sources/nix13/extra/strnicmp.c
+++ b/sources/nix13/extra/strnicmp.c
@@ -1,7 +1,7 @@
 #include <ctype.h>
 #include <string.h>
 
-asm("_strncasecmp: .global strncasecmp");
+asm("_strncasecmp: .global _strncasecmp");
 int strnicmp(const char *s1,const char *s2,size_t len)
 { unsigned char c1,c2;
   int r;


### PR DESCRIPTION
A typo in 7da928e broke strncasecmp when compiling with -mcrt=nix13 due
to a missing underscore.