### PR TITLE
allow libnix to be build with -pg

### DIFF
--- a/Makefile.gcc6
+++ b/Makefile.gcc6
@@ -236,7 +236,7 @@ lib$(libname).a: $(shell find $(root)/sources/$(lib)/* -name '*.c') $(stolen) $(
 	@if [ "$$(find $(root)/Makefile.gcc6 -newer $(lib)/stamp)" != "" ]; then rm -f $(lib)/*.o $@; touch -t 0001010000 $(lib)/stamp; fi
 	@cd $(lib) && files="$$(find $^ -name '*.c' -newer stamp)" && echo "$(CC) -c $(CFLAGS) $(flags) $$files" && \
 	$(CC) -c $(CFLAGS) $(flags) $$files && \
-	$(CC) -c $(CFLAGS) $(flags) -fomit-frame-pointer $(root)/sources/misc/swapstack.c
+	$(CC) -c $$(echo $(CFLAGS) | sed 's/-pg//g') $(flags) -fomit-frame-pointer $(root)/sources/misc/swapstack.c
 	@#echo archive $(kind)/$@
 	@$(AR) rcs $@ $$(find ./$(lib)/* -name '*.o' -newer $(lib)/stamp)
 

--- a/Makefile.gcc6
+++ b/Makefile.gcc6
@@ -236,7 +236,7 @@ lib$(libname).a: $(shell find $(root)/sources/$(lib)/* -name '*.c') $(stolen) $(
 	@if [ "$$(find $(root)/Makefile.gcc6 -newer $(lib)/stamp)" != "" ]; then rm -f $(lib)/*.o $@; touch -t 0001010000 $(lib)/stamp; fi
 	@cd $(lib) && files="$$(find $^ -name '*.c' -newer stamp)" && echo "$(CC) -c $(CFLAGS) $(flags) $$files" && \
 	$(CC) -c $(CFLAGS) $(flags) $$files && \
-	$(CC) -c $$(echo $(CFLAGS) | sed 's/-pg//g') $(flags) -fomit-frame-pointer $(root)/sources/misc/swapstack.c
+	$(CC) -c $(flags) -Os -fomit-frame-pointer $(root)/sources/misc/swapstack.c
 	@#echo archive $(kind)/$@
 	@$(AR) rcs $@ $$(find ./$(lib)/* -name '*.o' -newer $(lib)/stamp)
 


### PR DESCRIPTION
Sometimes I want to build libnix with profiling, so I pass -pg to the command line .

`CFLAGS_FOR_TARGET="-g -pg -Os" make libnix -j2 PREFIX=/home/developer/opt/m68k-amigaos_11May22`

That fails however because "-fomit-frame-pointer" cannot be used together with "-pg"

I changed the makefile to remove a potentially provided "-pg" from the CFLAGS for the compilation of swapstack.
