### PR TITLE
__cpucheck.c should have higest priority

### DIFF
--- a/sources/nix/misc/__cpucheck.c
+++ b/sources/nix/misc/__cpucheck.c
@@ -37,7 +37,7 @@ asm(
 "	jsr	_exit;"		/* dito */
 );
 
-ADD2INIT(__cpucheck,-79); /* Highest priority */
+ADD2INIT(__cpucheck,-80); /* Highest priority */
 
 #else
 

--- a/sources/nix/misc/__initlibraries.c
+++ b/sources/nix/misc/__initlibraries.c
@@ -60,5 +60,5 @@ void __exitlibraries(void) {
 	}
 }
 
-ADD2INIT(__initlibraries, -80);
-ADD2EXIT(__exitlibraries, -80);
+ADD2INIT(__initlibraries, -79);
+ADD2EXIT(__exitlibraries, -79);


### PR DESCRIPTION
A program compiled for 68040 crashed on 68000 (vamos) when there was no rexxsyslib.library installed.
It should have been aborted with the "cpucheck 68020-Alert" before.

Exchanging the priorities to make __cpucheck.c highest priority again solved the problem.
There is even an old comment in __cpucheck.c saying /* Highest priority */ but in fact __initlibraries.c had higher prio. 