### PR TITLE
Check for CPU>=68020 not always compiled in

### DIFF
--- a/sources/nix/misc/__cpucheck.c
+++ b/sources/nix/misc/__cpucheck.c
@@ -1,7 +1,7 @@
 #include "bases.h"
 #include "stabs.h"
 
-#if defined(mc68020)
+#if defined(mc68020) || defined(mc68030) || defined(mc68040) || defined(mc68060) || defined(mc68080)
 
 asm(
 "	.text;"


### PR DESCRIPTION
The check for CPUs greater than 68020 was not compiled in if a CPU > 68020 was selected via -m68030, -m68040, -m68060 etc