### PR TITLE
Add missing execbase.h includes

### DIFF
--- a/sources/nix/misc/stkchk.c
+++ b/sources/nix/misc/stkchk.c
@@ -1,3 +1,4 @@
+#include <exec/execbase.h>
 #include <proto/dos.h>
 #include <proto/exec.h>
 

--- a/sources/nix20/stdio/amistdio.c
+++ b/sources/nix20/stdio/amistdio.c
@@ -3,6 +3,7 @@
 #include <stabs.h>
 
 #include <dos/dosextens.h>
+#include <exec/execbase.h>
 #include <proto/dos.h>
 #include <proto/exec.h>
 


### PR DESCRIPTION
When compiling with NDK 3.9 I had a couple errors because the ExecBase struct wasn't defined. 