### PR TITLE
Possible multiple LVO definitions in compiled Libnix startup files (n_crt0.S) and pre-compiled libamiga.a

### DIFF
--- a/sources/startup/nbcrt0.S
+++ b/sources/startup/nbcrt0.S
@@ -2,13 +2,13 @@
 | (c) by M.Fleischer and G.Nikl Wed Apr 13 17:45 1994
 | No bugs known
 
-| some specific defines
+| some specific defines (disabled to prevent multiple definition - main source = libamiga.a
 
-_LVOForbid	=	-132
-_LVOFindTask	=	-294
-_LVOGetMsg	=	-372
-_LVOReplyMsg	=	-378
-_LVOWaitPort	=	-384
+| _LVOForbid	=	-132
+| _LVOFindTask	=	-294
+| _LVOGetMsg	=	-372
+| _LVOReplyMsg	=	-378
+| _LVOWaitPort	=	-384
 
 pr_MsgPort	=	  92
 pr_CLI		=	 172

--- a/sources/startup/ncrt0.S
+++ b/sources/startup/ncrt0.S
@@ -2,13 +2,13 @@
 | (c) by M.Fleischer and G.Nikl Wed Apr 13 17:44 1994
 | No bugs known
 
-| some specific defines
+| some specific defines (disabled to prevent multiple definition - main source = libamiga.a
 
-_LVOForbid	=	-132
-_LVOFindTask	=	-294
-_LVOGetMsg	=	-372
-_LVOReplyMsg	=	-378
-_LVOWaitPort	=	-384
+| _LVOForbid	=	-132
+| _LVOFindTask	=	-294
+| _LVOGetMsg	=	-372
+| _LVOReplyMsg	=	-378
+| _LVOWaitPort	=	-384
 
 pr_MsgPort	=	  92
 pr_CLI		=	 172

--- a/sources/startup/nlbcrt0.S
+++ b/sources/startup/nlbcrt0.S
@@ -2,13 +2,13 @@
 | (c) by M.Fleischer and G.Nikl Wed Apr 13 17:45 1994
 | No bugs known
 
-| some specific defines
+| some specific defines (disabled to prevent multiple definition - main source = libamiga.a
 
-_LVOForbid	=	-132
-_LVOFindTask	=	-294
-_LVOGetMsg	=	-372
-_LVOReplyMsg	=	-378
-_LVOWaitPort	=	-384
+| _LVOForbid	=	-132
+| _LVOFindTask	=	-294
+| _LVOGetMsg	=	-372
+| _LVOReplyMsg	=	-378
+| _LVOWaitPort	=	-384
 
 pr_MsgPort	=	  92
 pr_CLI		=	 172

--- a/sources/startup/nlrcrt0.S
+++ b/sources/startup/nlrcrt0.S
@@ -7,16 +7,16 @@
 |
 | You should use the non-resident startup-code if you need it !
 
-| some specific defines
+| some specific defines (disabled, main source = libamiga.a)
 
-_LVOForbid	=	-132
-_LVOAllocMem	=	-198
-_LVOFindTask	=	-294
-_LVOFreeMem	=	-210
-_LVOGetMsg	=	-372
-_LVOReplyMsg	=	-378
-_LVOWaitPort	=	-384
-_LVOCopyMemQuick =	-630
+| _LVOForbid	=	-132
+| _LVOAllocMem	=	-198
+| _LVOFindTask	=	-294
+| _LVOFreeMem	=	-210
+| _LVOGetMsg	=	-372
+| _LVOReplyMsg	=	-378
+| _LVOWaitPort	=	-384
+| _LVOCopyMemQuick =	-630
 
 tc_TrapData =     46
 pr_MsgPort	=	  92

--- a/sources/startup/nrcrt0.S
+++ b/sources/startup/nrcrt0.S
@@ -7,16 +7,16 @@
 |
 | You should use the non-resident startup-code if you need it !
 
-| some specific defines
+| some specific defines (disabled, main source = libamiga.a)
 
-_LVOForbid	=	-132
-_LVOAllocMem	=	-198
-_LVOFindTask	=	-294
-_LVOFreeMem	=	-210
-_LVOGetMsg	=	-372
-_LVOReplyMsg	=	-378
-_LVOWaitPort	=	-384
-_LVOCopyMemQuick =	-630
+| _LVOForbid	=	-132
+| _LVOAllocMem	=	-198
+| _LVOFindTask	=	-294
+| _LVOFreeMem	=	-210
+| _LVOGetMsg	=	-372
+| _LVOReplyMsg	=	-378
+| _LVOWaitPort	=	-384
+| _LVOCopyMemQuick =	-630
 
 tc_TrapData =     46
 pr_MsgPort	=	  92


### PR DESCRIPTION
Hello Stefan,

I ran into "multiple definition" linker errors when compiling ASM routines using LVO-offset defines from libamiga.a.

After some research I discovered that the Libnix startup files have some of their own LVO defines in t he n_crt0.s code.

Unless my understanding is wrong, I believe these "local" LVO defines are to be disabled, because Libnix itself is compiled with libamiga.a which contains all Amiga related LVO defines.

Greetings,

Willem