### PR TITLE
Fix window and requester library file names

### DIFF
--- a/sources/stubs/libbases/requester.c
+++ b/sources/stubs/libbases/requester.c
@@ -7,7 +7,7 @@ extern "C" {
 #if defined (__libnix__)
 
 __attribute__((section(".dlist___LIB_LIST__")))
-void* RequesterBase[2] = { (void*)-1, "requester.library" };
+void* RequesterBase[2] = { (void*)-1, "requester.class" };
 
 #elif defined (__AMIGAOS4__)
 
@@ -28,7 +28,7 @@ void __exit_Requester(void) __attribute__((destructor));
 
 void __init_Requester(void) {
   if (RequesterBase == NULL) {
-    RequesterBase = (struct Library *) IExec->OpenLibrary("requester.library", 0);
+    RequesterBase = (struct Library *) IExec->OpenLibrary("requester.class", 0);
     assert(RequesterBase != NULL);
   }
   if (IRequester == NULL) {

--- a/sources/stubs/libbases/window.c
+++ b/sources/stubs/libbases/window.c
@@ -7,7 +7,7 @@ extern "C" {
 #if defined (__libnix__)
 
 __attribute__((section(".dlist___LIB_LIST__")))
-void* WindowBase[2] = { (void*)-1, "window.library" };
+void* WindowBase[2] = { (void*)-1, "window.class" };
 
 #elif defined (__AMIGAOS4__)
 
@@ -28,7 +28,7 @@ void __exit_Window(void) __attribute__((destructor));
 
 void __init_Window(void) {
   if (WindowBase == NULL) {
-    WindowBase = (struct Library *) IExec->OpenLibrary("window.library", 0);
+    WindowBase = (struct Library *) IExec->OpenLibrary("window.class", 0);
     assert(WindowBase != NULL);
   }
   if (IWindow == NULL) {


### PR DESCRIPTION
The correct file for window and requester are window.class and requester.class. Trying to use these libraries will cause the auto library opening to fail because it looks for .library files instead of .class files.